### PR TITLE
Only load models if modelsPath is set

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -98,19 +98,20 @@ class Admin
 		self
 
 	_readModels: (path, done)->
-		debug 'Reading models at %s, from %s', path, process.cwd()
-		fs.readdir path, (err, files)->
-			debug 'Got the following model files:', files
-			for f in files
-				require "#{path}/#{f}"
+		if path
+			debug 'Reading models at %s, from %s', path, process.cwd()
+			fs.readdir path, (err, files)->
+				debug 'Got the following model files:', files
+				for f in files
+					require "#{path}/#{f}"
 
-			models = {}
-			for modelName, model of mongoose.models
-				models[model.collection.name] = model
-			debug 'Models: obj', Object.keys(models)
-			debug 'Models: mongoose', Object.keys(mongoose.models)
-			
-			return done(null, models)
+		models = {}
+		for modelName, model of mongoose.models
+			models[model.collection.name] = model
+		debug 'Models: obj', Object.keys(models)
+		debug 'Models: mongoose', Object.keys(mongoose.models)
+		
+		return done(null, models)
 
 
 	getModelDetails: (vModel)=>


### PR DESCRIPTION
My models are in subdirectories like this:

```
api/user
  user.controller.js
  user.model.js
api/song
  song.controller.js
  song.model.js
```

I load the models using a custom function and then create `penguin.Admin` with this:

```
  var admin = new penguin.Admin({
    modelsPath: null,
  });
```

Maybe a better way to do it would be to add a boolean.
