### PR TITLE
Add support for nested fields and additional Mixed and Array mongoose field types

### DIFF
--- a/example/models/user.coffee
+++ b/example/models/user.coffee
@@ -6,6 +6,16 @@ userSchema  = mongoose.Schema {
     email:          {type: String, $p: {label: 'E-Mail'}}
     password:       {type: String, $p: {hide: true}}
     isAdmin:        {type: Boolean}
+    tags: {type: Array, default: []}
+    meta: {
+        slug: {type: String}
+        thumb: {type: String}
+        settings: {type: mongoose.Schema.Types.Mixed}
+        deepMeta: {
+            deepSlug: String
+        }
+    }
+    data: mongoose.Schema.Types.Mixed
 }
 
 userSchema.virtual('$pTitle').get ()-> this.username

--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,10 @@
 {
   "dependencies": {
     "async": "~0.9.0",
+    "connect-flash": "^0.1.1",
+    "cookie-parser": "^1.3.4",
     "express": "~4.6.1",
+    "express-session": "^1.10.3",
     "mongoose": "~3.8.13"
   }
 }

--- a/example/public/admin/script.js
+++ b/example/public/admin/script.js
@@ -2,6 +2,10 @@
   CKEDITOR.config.filebrowserImageUploadUrl = '/admin/_upload';
 
   $('textarea').each(function() {
+    if ($(this).hasClass('field-widget-mixed-control')) {
+      // don't instantiate CKEDITOR for textareas with above className
+      return;
+    }
     CKEDITOR.replace(this.id);
   });
 

--- a/example/seed.coffee
+++ b/example/seed.coffee
@@ -13,7 +13,7 @@ Seeds = {
 		{type: 'a', published: true, user: IDs[0], date: new Date(), title: 'Welcome', content: 'Welcome to our new home...'}
 	]
 	User: [
-		{_id: IDs[0], username: 'Master', email: 'master@example.org', password: 'plaintextpass', isAdmin: true}
+		{_id: IDs[0], username: 'Master', email: 'master@example.org', password: 'plaintextpass', isAdmin: true, data: { alternateEmail: 'master2@example.org'}, meta: { slug: 'admin-master', settings: { hasLoggedOn: false, lastLoginDate: Date.now() }, deepMeta: { deepSlug: 'deep-admin-master'}}, tags: ['admin', 'master', 'keyMaster']}
 		{_id: IDs[1], username: 'Peon', email: 'peon@example.org', password: 'usebcrypttostorepasswords!', isAdmin: false}
 	]
 }

--- a/src/defaults.coffee
+++ b/src/defaults.coffee
@@ -41,6 +41,8 @@ d.typesMap = { # constructor / widget
 	String:		['string', 'text']
 	Boolean:	['boolean', 'checkbox']
 	Date:		['string', 'datetime']
+	Mixed:		['string', 'mixed']
+	Array:		['string', 'mixed']
 }
 d.res$p = {
 	viewBlocks: {}

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -414,20 +414,24 @@ class Admin
 					dataToSet = {}
 					dataToSet[k]=v for k,v of nform.data
 
-					# Just unset the '' file fields from the data to be set in the row
+					# parse field values
 					for field in req.$p.model.fields
-						if 'ObjectID' == field.instance && 'File' == field.options.ref && !dataToSet[field.path]
+						value = dataToSet[field.path]
+						#console.log('widget.type',nform.fields[field.path].widget.type, value);
+						# Just unset the '' file fields from the data to be set in the row
+						if 'ObjectID' == field.instance && 'File' == field.options.ref && !value
 							delete dataToSet[field.path]
+						# unset datetime fields that are 'undefined' strings
+						if 'datetime' == nform.fields[field.path].widget.type  && 'undefined' == value
+							delete dataToSet[field.path]
+						# convert stringified 'mixed' widget value back
+						if 'mixed' == nform.fields[field.path].widget.type && nform.fields[field.path].widget.toValue
+							dataToSet[field.path] = nform.fields[k].widget.toValue(value)
 
 					# Also set the conditions as field values
 					if req.$p.addMode
 						dataToSet[k] = v for k, v of req.$p.model.conditions
 						#return res.send 'WIP'
-
-					# convert stringified 'mixed' widget value back
-					for k,v of dataToSet
-						if nform.fields[k].widget.type == 'mixed' && nform.fields[k].widget.toValue
-							dataToSet[k] = nform.fields[k].widget.toValue(v)
 
 					# map value of flattened nested paths to mongo document
 					for k,v of dataToSet

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -34,4 +34,31 @@ utils.createMongoQueryFromRequest = (req)->
 		query = mongoQuery.sort(req.$p.model.sort)
 	mongoQuery
 
+utils.getFieldValueByPath = (doc, fieldPath)->
+	return if !doc
+	tokens = fieldPath.split('.')
+	fieldValue = doc;
+	for token in tokens
+		if typeof fieldValue[token] == 'undefined' || fieldValue[token] == null
+			fieldValue = fieldValue[token];
+			break;
+		fieldValue = fieldValue[token];
+	return fieldValue
+
+# Note: this function updates the field values in the doc directly
+utils.updateFieldValueByPath = (doc, fieldPath, value)->
+	tokens = fieldPath.split('.')
+	if tokens.length <= 1
+		# is not a flattened path, update value
+		doc[fieldPath]=value
+		return
+
+	# only iterate up to n-1 token, because we can to hold the reference while updating it
+	ref = doc
+	lastToken = tokens[tokens.length-1]
+	for token, i in tokens when i < tokens.length - 1
+		ref = ref[token]
+	# update value
+	ref[lastToken]=value
+
 module.exports = utils

--- a/src/widgets.coffee
+++ b/src/widgets.coffee
@@ -1,4 +1,3 @@
-merge = require 'merge'
 widgets = {}
 
 dateTimeToHTML = (name, f)->

--- a/src/widgets.coffee
+++ b/src/widgets.coffee
@@ -1,13 +1,46 @@
+merge = require 'merge'
 widgets = {}
 
-toHTML = (name, f)->
+dateTimeToHTML = (name, f)->
 	value = f.value
 	if f.value instanceof Date
 		value = f.value.toISOString().substr(0, 19)
 	"<input type=\"#{this.type}\" id=\"id_#{name}\" name=\"#{name}\" value=\"#{value}\" />"
 
-widgets.datetime =  (opt={})->
-	{ classes: opt.classes, type: 'datetime', toHTML: toHTML }
+textToHTML = (name, f)->
+	if !f.value
+		return "<input type=\"#{this.type}\" placeholder='Empty string' id=\"id_#{name}\" name=\"#{name}\" />"
+	value = f.value
+	return "<input type=\"#{this.type}\" id=\"id_#{name}\" name=\"#{name}\" value='#{value}' />"
 
+mixedToHTML = (name, f)->
+	# Note: the rendered HTML for this widget is overridden in form.jade eventually
+	if !f.value
+		return "<textarea id=\"id_#{name}\" name=\"#{name}\"></textarea>"
+
+	# stringify 'mixed' widget value
+	value = JSON.stringify(f.value)
+	return "<textarea class='classic-textarea' id=\"id_#{name}\" name=\"#{name}\">#{value}</textarea>"
+
+stringifiedToMixed = (str)->
+	try
+		return JSON.parse(str)
+	catch
+		val = parseFloat(str)
+		return if !isNaN val
+		return true if str.toLowerCase() == 'true'
+		return false if str.toLowerCase() == 'false'
+		# if we can't parse it into an object/float/int/bool, just return it back as a str
+		# and let mongodb try to save it since its a Mixed type
+		return str
+
+widgets.datetime =  (opt={})->
+	{ classes: opt.classes, type: 'datetime', toHTML: dateTimeToHTML }
+
+widgets.text =  (opt={})->
+	{ classes: opt.classes, type: 'text', toHTML: textToHTML }
+
+widgets.mixed =  (opt={})->
+	{ classes: opt.classes, type: 'mixed', toHTML: mixedToHTML, toValue: stringifiedToMixed }
 
 module.exports = widgets

--- a/views/collection.jade
+++ b/views/collection.jade
@@ -44,7 +44,9 @@ block content
 					each field in model.fields
 						- var fieldValue = row[field.path]
 						- if (-1 == field.$p.display.indexOf('l')) continue;
-						if 'ObjectID' == field.instance && fieldValue
+						if typeof fieldValue == 'undefined' || fieldValue == null
+							td!='&mdash;'
+						else if 'ObjectID' == field.instance
 							td
 								span.linked-document
 									a.fui-document(href='#{field.$p.getRefModel().path}/#{fieldValue._id}', title='Edit Linked Document')
@@ -52,6 +54,12 @@ block content
 									=fieldValue.$pTitle
 						else if fieldValue instanceof Date
 							td(title=fieldValue)=fieldValue.toISOString().substr(0, 19).replace('T', ' ')
+						else if Array.isArray(fieldValue)
+							td
+								i='array'
+						else if typeof fieldValue === 'object'
+							td
+								i='object'
 						else
 							//- console.log (field.options.type.name)
 							td=fieldValue

--- a/views/p/form.jade
+++ b/views/p/form.jade
@@ -112,7 +112,11 @@ mixin display_field(field, name)
 			div(class=det.fieldClasses)
 				input.form-control(type='text', id=det.id, name='#{name}_label', value=field.value? field.value.$pTitle : '')
 				input(id="#{det.id}_id", type='hidden', name=name, value=field.value? field.value._id.toString(): '')
-
+		else if 'mixed' == field.widget.type
+			+label(field, name, det)
+			div(class=det.fieldClasses)
+				textarea.form-control.field-widget-mixed-control(id=det.id, name='#{name}').
+					!{JSON.stringify(field.value)}
 		else
 			//- console.log (field.$pField)
 			+label(field, name, det)


### PR DESCRIPTION
**Enhancements**
Related to issue #6 
Add support for 
- nested fields
- additional Mixed and Array mongoose field types
  - both types are handled by a new 'mixed' form widget

Currently, editing values of Mixed and Array field types are done using plain textarea.

If the values are not parseable by JSON.parse back to their respective types, 
it will be saved as String in mongodb.

A possible enhancement later would be to find a proper JSON editor.
If anyone can recommend a good one, I might be able to integrate them.

**Fixes**
- An issue with saving undefined datetime

Hope this helps!