### PR TITLE
Allow custom ID's for models

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -266,7 +266,6 @@ class Admin
 		return next()
 
 	pId: (req, res, next)->
-		return res.send(404) if not req.params.id.match /^[0-9a-f]{24}$/
 		query = req.$p.model.obj.findById(req.params.id)
 		query = query.populate req.$p.model.fieldsToPopulate.join(' ')
 		query.exec (err, doc)->


### PR DESCRIPTION
Currently any Id that does not match /^[0-9a-f]{24}$/ will result in a 404. I am using UUID's in a project so none of the models ever load 😢 